### PR TITLE
Action tweaks

### DIFF
--- a/PYME/Acquire/ActionManager.py
+++ b/PYME/Acquire/ActionManager.py
@@ -256,9 +256,9 @@ class ActionManager(object):
         Examples
         --------
         
-        >>> my_actions = [UpdateState({'Camera.ROI' : [50, 50, 200, 200]}),
+        >>> my_actions = [UpdateState(state={'Camera.ROI' : [50, 50, 200, 200]}),
         >>>      SpoolSeries(maxFrames=500, stack=False),
-        >>>      UpdateState({'Camera.ROI' : [100, 100, 250, 250]}).then(SpoolSeries(maxFrames=500, stack=False)),
+        >>>      UpdateState(state={'Camera.ROI' : [100, 100, 250, 250]}).then(SpoolSeries(maxFrames=500, stack=False)),
         >>>      ]
         >>>
         >>>ActionManager.queue_actions(my_actions)

--- a/PYME/Acquire/ActionManager.py
+++ b/PYME/Acquire/ActionManager.py
@@ -121,16 +121,12 @@ def action_from_dict(serialised):
     act, params = list(serialised.items())[0]
     
     then = params.pop('then', None)
-    try:
-        # TODO - use a slightly less broad dictionary for action lookup (or move actions to a separate module)
-        a = globals()[act](**params)
-    except KeyError:
-        # Legacy string-based action queued in `Action` function method
-        logger.warn('string-based function queuing is deprecated, see ActionManager.FunctionAction')
-        return FunctionAction(act, params)
+    # TODO - use a slightly less broad dictionary for action lookup (or move actions to a separate module)
+    a = globals()[act](**params)
+
     if then:
         a.then(action_from_dict(then))
-        
+    
     return a
 
 

--- a/PYME/Acquire/ActionManager.py
+++ b/PYME/Acquire/ActionManager.py
@@ -99,6 +99,10 @@ class CentreROIOn(StateAction):
         # TODO - write this however David wanted it
     def __call__(self, scope):
         scope.centre_roi_on(self.params['x'], self.params['y'])
+        return self._do_then(scope)
+    
+    def __repr__(self):
+        return 'CentreROIOn: %f, %f (x, y)' % (self.params['x'], self.params['y'])
         
 
 class SpoolSeries(Action):

--- a/PYME/Acquire/ui/tile_panel.py
+++ b/PYME/Acquire/ui/tile_panel.py
@@ -330,6 +330,7 @@ class MultiwellProtocolQueuePanel(wx.Panel):
 
     def OnQueue(self, event=None):
         import numpy as np
+        from PYME.Acquire.ActionManager import UpdateState, SpoolSeries, FunctionAction
         from PYME.Acquire import protocol
         tile_protocols = [p for p in protocol.get_protocol_list() if 'tile' in p]
 
@@ -378,13 +379,13 @@ class MultiwellProtocolQueuePanel(wx.Panel):
         y_wells += curr_pos['y']
 
         # queue them all
+        actions = list()
         for x, y, filename in zip(x_wells, y_wells, names):
-            args = {'state': {'Positioning.x': x, 'Positioning.y': y}}
-            self.scope.actions.QueueAction('state.update', args, nice)
-            args = {'protocol': protocol_name, 'stack': False, 
-                    'doPreflightCheck':False, 'fn': filename}
-            self.scope.actions.QueueAction('spoolController.StartSpooling', 
-                                            args, nice)
-        self.scope.actions.QueueAction('turnAllLasersOff', 
-                                            {}, nice)
+            state = UpdateState({'Positioning.x': x, 'Positioning.y': y})
+            spool = SpoolSeries(protocol=protocol_name, stack=False, 
+                                doPreflightCheck=False, fn=filename)
+            actions.append(state.then(spool))
+        
+        actions.append(FunctionAction('turnAllLasersOff', {}))
+        self.scope.actions.queue_actions(actions, nice)
         

--- a/PYME/Acquire/ui/tile_panel.py
+++ b/PYME/Acquire/ui/tile_panel.py
@@ -381,7 +381,7 @@ class MultiwellProtocolQueuePanel(wx.Panel):
         # queue them all
         actions = list()
         for x, y, filename in zip(x_wells, y_wells, names):
-            state = UpdateState({'Positioning.x': x, 'Positioning.y': y})
+            state = UpdateState(state={'Positioning.x': x, 'Positioning.y': y})
             spool = SpoolSeries(protocol=protocol_name, stack=False, 
                                 doPreflightCheck=False, fn=filename)
             actions.append(state.then(spool))

--- a/PYME/recipes/acquisition.py
+++ b/PYME/recipes/acquisition.py
@@ -137,6 +137,7 @@ class QueueAcquisitions(OutputModule):
                         data=json.dumps(actions),
                         headers={'Content-Type': 'application/json'})
         
+        # queue a high-nice call to shut off all lasers when we're done
         session.post(dest + '?timeout=%f&nice=%d&max_duration=%f' % (self.timeout,
                                                                         np.iinfo(int).max,
                                                                         self.max_duration),
@@ -145,11 +146,4 @@ class QueueAcquisitions(OutputModule):
                                 'functionName': 'turnAllLasersOff', 'args': {}
                                 }
                             }]),
-                        headers={'Content-Type': 'application/json'})
-        
-        # queue a high-nice call to shut off all lasers when we're done
-        session.post(dest + '?timeout=%f&nice=%d&max_duration=%f' % (self.timeout,
-                                                                        np.iinfo(int).max,
-                                                                        self.max_duration),
-                        data=json.dumps([{'turnAllLasersOff': {}}]),
                         headers={'Content-Type': 'application/json'})

--- a/PYME/recipes/acquisition.py
+++ b/PYME/recipes/acquisition.py
@@ -127,9 +127,7 @@ class QueueAcquisitions(OutputModule):
                 'CentreROIOn':{
                     'x': positions[ri, 0], 'y': positions[ri, 1],
                     'then': {
-                        'SpoolSeries' : {
-                            'spool_settings': spool_settings,
-                        }
+                        'SpoolSeries' : spool_settings
                     }
                 }
             })

--- a/PYME/recipes/acquisition.py
+++ b/PYME/recipes/acquisition.py
@@ -137,6 +137,16 @@ class QueueAcquisitions(OutputModule):
                         data=json.dumps(actions),
                         headers={'Content-Type': 'application/json'})
         
+        session.post(dest + '?timeout=%f&nice=%d&max_duration=%f' % (self.timeout,
+                                                                        np.iinfo(int).max,
+                                                                        self.max_duration),
+                        data=json.dumps([{
+                            'FunctionAction': {
+                                'functionName': 'turnAllLasersOff', 'args': {}
+                                }
+                            }]),
+                        headers={'Content-Type': 'application/json'})
+        
         # queue a high-nice call to shut off all lasers when we're done
         session.post(dest + '?timeout=%f&nice=%d&max_duration=%f' % (self.timeout,
                                                                         np.iinfo(int).max,


### PR DESCRIPTION
Addresses issues:
- small bugfixes (type queue_acquisitions query strings, py3 index dict_items err, etc.)
- hack in something to let `turnAllLasersOff` run
- update `QueueAcquisitions` to use `queue_actions`
- unit test for `QueueAcquisitions`