### PR TITLE
Htsms sim

### DIFF
--- a/PYME/Acquire/Scripts/init_sim_htsms.py
+++ b/PYME/Acquire/Scripts/init_sim_htsms.py
@@ -215,6 +215,14 @@ def action_manager(MainFrame, scope):
     #ap = tile_panel.MultiwellProtocolQueuePanel(MainFrame, scope)
     #MainFrame.aqPanels.append((ap, 'Multiwell Tile Acquisition'))
 
+@init_gui('Chained Analysis')
+def chained_analysis(main_frame, scope):
+    from PYME.Acquire.htsms.rule_ui import SMLMChainedAnalysisPanel, get_rule_tile, RuleChain
+    from PYME.cluster.rules import RecipeRuleFactory, SpoolLocalLocalizationRuleFactory
+    from PYME.IO.MetaDataHandler import DictMDHandler
+    
+    SMLMChainedAnalysisPanel.plug(main_frame, scope)
+
 
 #must be here!!!
 joinBGInit() #wait for anyhting which was being done in a separate thread

--- a/PYME/Acquire/htsms/rule_ui.py
+++ b/PYME/Acquire/htsms/rule_ui.py
@@ -115,6 +115,11 @@ class ProtocolRules(OrderedDict):
             logger.info('inactive, check "active" to turn on auto analysis')
             return
         spooler = self._spool_controller.spooler
+        try:
+            spooler.getURL
+        except AtrributeError:
+            logger.exception('Rule-based analysis chaining currently requires spooling to cluster, not to file')
+            raise 
         prot_filename = spooler.protocol.filename
         prot_filename = '' if prot_filename is None else prot_filename
         protocol_name = os.path.splitext(os.path.split(prot_filename)[-1])[0]

--- a/PYME/IO/HTTPSpooler_v2.py
+++ b/PYME/IO/HTTPSpooler_v2.py
@@ -64,7 +64,7 @@ from PYME.IO import acquisition_backends
 class Spooler(sp.Spooler):
     def __init__(self, filename, frameSource, frameShape, **kwargs):
         sp.Spooler.__init__(self, filename, frameSource, **kwargs)
- 
+        
         self.seriesName = getReducedFilename(filename)        
         self._aggregate_h5 = kwargs.get('aggregate_h5', False)
         
@@ -92,6 +92,7 @@ class Spooler(sp.Spooler):
         
         self.md = self._backend.mdh
         self.evtLogger = MemoryEventLogger(self, time_fcn=self._time_fcn)
+        self._stopping = False
                 
     def finished(self):
         # FIXME - this probably needs a bit more work.


### PR DESCRIPTION


**Proposed changes:**
- add the analysis GUI for linking
- set up the _stopping in httpspooler_v2 (note that I have not read the new implementation in acquisition_backends)
- check that we have an httpspooler in rule_ui


Still to come:
- simulation protocol to turn on/off the laser

Could use a hand from @David-Baddeley if you have a minute:
- I never got the localization settings fold out in the rule page to work properly. At the moment you have to go to the `page`, where you'll initially see nothing, and click the top to expand it down. Then you'll see the arrow you can expand to see settings, but it doesn't re-size so you can actually view anything unless you click the top bar again to make it disappear, then click it again to open it with that folding bit now expanded. Was never an issue for me because I just had my localization settings pre-loaded as a default for my SMLM protocols in my init script.






