### PR TITLE
splitter stuff - fix remaining live unmixing issues

### DIFF
--- a/PYME/Acquire/Hardware/splitter.py
+++ b/PYME/Acquire/Hardware/splitter.py
@@ -40,9 +40,11 @@ class Splitter(object):
         self.cam = cam
         self.flipChan=flipChan
         self.parent = parent
-        self.unmixer = splitting.Unmixer(flip=flip, axis = dir)
         self.flip = flip
         self._rois=rois
+        pixelsize_nm = 1e3*(scope.GetPixelSize(cam)[0])
+        self.unmixer = splitting.Unmixer(flip=flip, axis = dir, chanROIs=self.rois, pixelsize=pixelsize_nm)
+
 
         #which dichroic mirror is installed
         self.dichroic = dichroic

--- a/PYME/Acquire/microscope.py
+++ b/PYME/Acquire/microscope.py
@@ -439,7 +439,7 @@ class microscope(object):
                 conn.execute("CREATE TABLE StartupTimes (component TEXT, time REAL)")
                 conn.execute("INSERT INTO StartupTimes VALUES ('total', 5)")
 
-    def GetPixelSize(self):
+    def GetPixelSize(self,cam=None):
         """Get the (sample space) pixel size for the current camera
         
         Returns
@@ -448,18 +448,21 @@ class microscope(object):
         pixelsize : tuple
             the pixel size in the x and y axes, in um
         """
+
+        if cam is None:
+            cam = self.cam
         with self.settingsDB as conn:
-            currVoxelSizeID = conn.execute("SELECT sizeID FROM VoxelSizeHistory2 WHERE camSerial=? ORDER BY time DESC", (self.cam.GetSerialNumber(),)).fetchone()
+            currVoxelSizeID = conn.execute("SELECT sizeID FROM VoxelSizeHistory2 WHERE camSerial=? ORDER BY time DESC", (cam.GetSerialNumber(),)).fetchone()
             if not currVoxelSizeID is None:
                 voxx, voxy = conn.execute("SELECT x,y FROM VoxelSizes WHERE ID=?", currVoxelSizeID).fetchone()
                 
-                return voxx*self.cam.GetHorizontalBin(), voxy*self.cam.GetVerticalBin()
-            elif hasattr(self.cam, 'XVals'): # change to looking for attribute so that wrapped (e.g. multiview) cameras still work
+                return voxx*cam.GetHorizontalBin(), voxy*cam.GetVerticalBin()
+            elif hasattr(cam, 'XVals'): # change to looking for attribute so that wrapped (e.g. multiview) cameras still work
                 # read voxel size from directly from our simulated camera
                 logger.info('Reading voxel size directly from simulated camera')
-                vx_um = float(self.cam.XVals[1] - self.cam.XVals[0]) / 1.0e3
-                vy_um = float(self.cam.YVals[1] - self.cam.YVals[0]) / 1.0e3
-                return vx_um * self.cam.GetHorizontalBin(), vy_um * self.cam.GetVerticalBin()
+                vx_um = float(cam.XVals[1] - cam.XVals[0]) / 1.0e3
+                vy_um = float(cam.YVals[1] - cam.YVals[0]) / 1.0e3
+                return vx_um * cam.GetHorizontalBin(), vy_um * cam.GetVerticalBin()
                     
 
     def GenStartMetadata(self, mdh):

--- a/PYME/Analysis/splitting.py
+++ b/PYME/Analysis/splitting.py
@@ -115,7 +115,7 @@ class SplittingInfo(object):
                     (0, h / 2, 2, h / 2)
                 ]
             
-        self.flip_y = np.zeros(len(self.chanROIs), dtype=np.int)
+        self.flip_y = np.zeros(len(self.chanROIs), dtype=int)
         if self._flip:
             self.flip_y[1] = 1
 

--- a/PYME/Analysis/splitting.py
+++ b/PYME/Analysis/splitting.py
@@ -58,6 +58,7 @@ class SplittingInfo(object):
             self.chanROIs = chanROIs
             self.camera_roi_origin = ROI[:2]
             self.data_shape = np.array(ROI[2:]) - np.array(ROI[:2])
+            self._flip = flip
         else:
             # assume we have been passed an mdh and data_shape  
             from PYME.IO.MetaDataHandler import get_camera_roi_origin


### PR DESCRIPTION
Just realised I should raise the remaining fixes we needed to get this to work against your fork of the repo where the `splitter_stuff` branch resides.

I had mentioned this commit in the PR discussion (Splitter tidying #1445).

Note the subtle change in `PYME/Acquire/microscope.py` to make obtaining the pixelsize easier if the cam in question is not the currently active cam. This happens on our setup regulalrly as we have 2 cams, one with and one without splitter. The splitter magnification is different on different setups, so passing the pixelsize seems necessary and prudent.

We'll test further but this seems to work now as is.